### PR TITLE
Add site: bookdown::bookdown_site

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -3,15 +3,15 @@ title: "Efficient R programming"
 author: "Colin Gillespie and Robin Lovelace"
 date: "`r Sys.Date()`"
 knit: "bookdown::render_book"
+site: bookdown::bookdown_site
 documentclass: book
 bibliography: refs.bib
 biblio-style: apalike
 link-citations: yes
 cover-image: figures/full.png
-new_session: yes
 description: "Efficient R programming."
 github-repo: csgillespie/efficientR
-url: "https://csgillespie.github.io/efficientR/"
+url: "https\://csgillespie.github.io/efficientR/"
 ---
 
 ```{r 0_setup, include=FALSE}

--- a/index.Rmd
+++ b/index.Rmd
@@ -11,7 +11,7 @@ link-citations: yes
 cover-image: figures/full.png
 description: "Efficient R programming."
 github-repo: csgillespie/efficientR
-url: "https\://csgillespie.github.io/efficientR/"
+url: 'https\://csgillespie.github.io/efficientR/'
 ---
 
 ```{r 0_setup, include=FALSE}


### PR DESCRIPTION
Removed new_session: yes since it is an option that belongs to _bookdown.yml instead of the YAML metadata here.

Added `\` to `url` because we don't want Pandoc to translate it to `<a href=...></a>`