### PR TITLE
Update 02-set-up.Rmd

### DIFF
--- a/02-set-up.Rmd
+++ b/02-set-up.Rmd
@@ -260,7 +260,7 @@ Note that we can now re-use the `pkgs` object to load them all:
 inst = lapply(pkgs, library, character.only = TRUE) # load them
 ```
 
-In the above code `library(pkg[i])` is executed for every package stored in the text string vector.
+In the above code `library(pkgs[i])` is executed for every package stored in the text string vector.
 We use `library` here instead of `require` because the former produces an error if the package is not available.
 
 Loading all packages at the beginning of a script is good practice as it ensures all dependencies have been installed *before* time is spent executing code.


### PR DESCRIPTION
Fixed a typo by changing to `library(pkgs[i])`