### PR TITLE
benchmarkme::get_linear_algebra() works on macOS

### DIFF
--- a/02-set-up.Rmd
+++ b/02-set-up.Rmd
@@ -1023,7 +1023,7 @@ The two open source alternative BLAS libraries are [ATLAS](http://math-atlas.sou
 designed for Intel processors by Intel and used in Revolution R
 (described in the next section) but it requires licensing fees. The MKL library is provided with the Revolution analytics system. Depending on your application, by switching your BLAS library, linear algebra operations can run several times faster than with the base BLAS routines. 
 
-If you use Linux, you can check whether you have a BLAS library setting with the following function, from **benchmarkme**:
+If you use macOS or Linux, you can check whether you have a BLAS library setting with the following function, from **benchmarkme**:
 
 ```{r, eval=FALSE}
 library("benchmarkme")


### PR DESCRIPTION
benchmarkme::get_linear_algebra() works on macOS, which is also noted in ?get_linear_algebra.