### PR TITLE
[fix] typo USArrests

### DIFF
--- a/08-hardware.Rmd
+++ b/08-hardware.Rmd
@@ -99,7 +99,7 @@ pryr::object_size(d)
 The distance object `d` is actually a vector that contains the distances in the upper triangular region. 
 ```
 
-we have managed to create an object that is three times larger than the original data set. In fact the object `d` is a symmetric $n \times n$ matrix, where $n$ is the number of rows in `USAarrests`. Clearly, as `n` increases the size of `d` increases at rate $O(n^2)$. So if our original data set contained $10,000$ records, the associated distance matrix would contain almost $10^8$ values. Of course since the matrix is symmetric, this corresponds to around $50$ million unique values. 
+we have managed to create an object that is three times larger than the original data set. In fact the object `d` is a symmetric $n \times n$ matrix, where $n$ is the number of rows in `USArrests`. Clearly, as `n` increases the size of `d` increases at rate $O(n^2)$. So if our original data set contained $10,000$ records, the associated distance matrix would contain almost $10^8$ values. Of course since the matrix is symmetric, this corresponds to around $50$ million unique values.
 
 ```{block, type="rmdtip"}
 A rough rule of thumb is that your RAM should be three times the size of your data set.


### PR DESCRIPTION
## Summary
Found a small typo 😄 

- Fix typo: `USAarrests` -> `USArrests` (removed a)
- Link: [USArrests](https://stat.ethz.ch/R-manual/R-devel/library/datasets/html/USArrests.html)

