### PR TITLE
[fix] Logic explanation

### DIFF
--- a/07-performance.Rmd
+++ b/07-performance.Rmd
@@ -235,7 +235,7 @@ as.numeric(levels(f))[f]
 
 ### Logical AND and OR {-}
 
-The logical AND (`&`) and OR (`|`) operators are vectorised functions and are typically used during multi-criteria subsetting operations. The code below, for example,  returns `TRUE` for all elements of `x` greater than $0.4$ or less than $0.6$:
+The logical AND (`&`) and OR (`|`) operators are vectorised functions and are typically used during multi-criteria subsetting operations. The code below, for example,  returns `TRUE` for all elements of `x` less than $0.4$ or greater than $0.6$.
 
 ```{r, echo=-1}
 x = c(0.2, 0.5, 0.7)


### PR DESCRIPTION
## Summary
- It seems the two numbers are mixed when explaining the below code.

The code it's referring to:

```r
 x = c(0.2, 0.5, 0.7)
 x < 0.4 | x > 0.6
 ```

Obviously, it returns `TRUE` for all elements of `x` less than 0.4 or greater than 0.6



