### PR TITLE
[fix] Sidebar Author Info

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -6,7 +6,8 @@ bookdown::gitbook:
       before: |
         <li><a href="./">Efficient R programming</a></li>
       after: |
-        <li><a href="http://www.jumpingrivers.com">Colin Gillespie</a>, Robin Lovelace</li>
+        <li><a href="http://www.jumpingrivers.com">Colin Gillespie</a></li>
+        <li><a href="http://www.robinlovelace.net">Robin Lovelace</a></li>
     edit:
       link: https://github.com/csgillespie/efficientR/edit/master/%s
       text: "Edit"
@@ -14,4 +15,3 @@ bookdown::pdf_book:
   includes:
     in_header: preamble.tex
   keep_tex: yes
-


### PR DESCRIPTION
## Summary
1. Fix the author information on the sidebar

## Before
- the alignment is bad
- @Robinlovelace  doesn't have a link
![image](https://user-images.githubusercontent.com/2981167/35344992-4eee4f6e-00e3-11e8-9dc7-e27b93c55431.png)

## After
- the alignment is perfect now
- link to @Robinlovelace 's website

![image](https://user-images.githubusercontent.com/2981167/35345045-70d5e1aa-00e3-11e8-8de8-23967d7ae0fa.png)


## Whole Screen
![image](https://user-images.githubusercontent.com/2981167/35345104-953554a4-00e3-11e8-88a4-39d8e7d83976.png)


