### PR TITLE
remove `mutate_each` since it is deprecated

### DIFF
--- a/06-data-carpentry.Rmd
+++ b/06-data-carpentry.Rmd
@@ -351,10 +351,10 @@ wb_ineq[cols_to_change] = as.numeric(unlist(wb_ineq[cols_to_change]))
 ```
 
 <!-- __XXX__ Seems odd that for a chapter on dplyr, the dplyr solution is last. Also you give 3 options. Which one is best? -->
-*Another* one-liner to achieve the same result uses **dplyr**'s `mutate_each` function: 
+*Another* one-liner to achieve the same result uses **dplyr**'s `mutate_at` function: 
 
 ```{r, warning=FALSE, echo=-2}
-wb_ineq = mutate_each(wb_ineq, "as.numeric", cols_to_change)
+wb_ineq = mutate_at(wb_ineq, vars(cols_to_change), funs(as.numeric))
 # This file is saved as wb_ineq in the efficient package
 ```
 


### PR DESCRIPTION
In ?mutate_each, we can find
```
mutate_each() and summarise_each() are deprecated in favour of a more featureful family of functions: mutate_all(), mutate_at(), mutate_if(), summarise_all(), summarise_at() and summarise_if()
```

