### PR TITLE
Added indentation fixes citations on Windows

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -11,7 +11,7 @@ link-citations: yes
 twitter-handle: csgillespie
 cover-image: figures/f0_web.png
 description: "Efficient R Programming is about increasing the amount of work you 
-can do with R in a given amount of time. It's about both computational and programmer efficiency."
+  can do with R in a given amount of time. It's about both computational and programmer efficiency."
 github-repo: csgillespie/efficientR
 url: 'https\://csgillespie.github.io/efficientR/'
 ---


### PR DESCRIPTION
For me, when trying to compile the book on Windows (Pandoc 2.3), citations are shown as question marks. The following warning from Pandoc is probably related to the issue: 

```
[WARNING] Could not parse YAML metadata at line 20 column 1: :13:81: Unexpected '
  '
```

I added indentation on one row in `index.Rmd` which fixes the problem.

## Before patch
![Screenshot where citations fail](https://user-images.githubusercontent.com/2980656/45959077-bea8fe00-c021-11e8-987e-dddb01d60cb9.png)
## After patch
![Patch fixes citations](https://user-images.githubusercontent.com/2980656/45959131-d84a4580-c021-11e8-954d-0728a4f96087.png)

Curiously, the book compiles fine either way on Linux (Pandoc 1.19.2.4).