### PR TITLE
add dependencies=TRUE to install_github line

### DIFF
--- a/01-introduction.Rmd
+++ b/01-introduction.Rmd
@@ -268,7 +268,7 @@ system.time(
 This book has an associated R package that contains data sets and functions referenced in the book. The package is hosted on [github](https://github.com/csgillespie/efficient) and can be installed using the **devtools** package:
 
 ```{r, eval=FALSE}
-devtools::install_github("csgillespie/efficient", build_vignettes = TRUE)
+devtools::install_github("csgillespie/efficient", build_vignettes = TRUE, dependencies = TRUE)
 ```
 
 The package also contains solutions (as vignettes) to the exercises found in this book. They can be browsed with the following command:


### PR DESCRIPTION
The line:
```
devtools::install_github("csgillespie/efficient",build_vignettes = TRUE)
```
is suggested to install vignettes for solution samples, but up until here in the book, a lot of the packages required in later chapters are not installed.

Suggested change is as follows:
```
devtools::install_github("csgillespie/efficient",build_vignettes = TRUE,dependencies=TRUE)
```