### PR TITLE
Alter erronous 'neval' microbenchmark() argument to 'times' in Chapter 1

### DIFF
--- a/01-introduction.Rmd
+++ b/01-introduction.Rmd
@@ -239,7 +239,7 @@ microbenchmark(cs_for(x), cs_apply(x), cumsum(x))
 
 1. Which method is fastest and how many times faster is it?
 
-2. Run the same benchmark, but with the results reported in seconds, on a vector of all the whole numbers from 1 to 50,000. Hint: also use the argument `neval = 1` so that each command is only run once to ensure the results complete (even with a single evaluation the benchmark may take up to or more than a minute to complete, depending on your system). Does the *relative* time difference increase or decrease? By how much?
+2. Run the same benchmark, but with the results reported in seconds, on a vector of all the whole numbers from 1 to 50,000. Hint: also use the argument `times = 1` so that each command is only run once to ensure the results complete (even with a single evaluation the benchmark may take up to or more than a minute to complete, depending on your system). Does the *relative* time difference increase or decrease? By how much?
 
 ```{r, eval=FALSE, echo=FALSE}
 x = 1:5e4 # initiate vector to cumulatively sum


### PR DESCRIPTION
Minor typo. In the exercises of Chapter 1 'neval' is given as an argument of microbenchmark() when it is in fact 'times'. Understandable given the output table gives an 'neval' column.