### PR TITLE
all packages are by default byte-compiled on installation

### DIFF
--- a/03-programming.Rmd
+++ b/03-programming.Rmd
@@ -657,24 +657,7 @@ local(source("code/03-programming_f4.R", local = TRUE))
 
 ### Compiling code
 
-There are a number of ways to compile code. The easiest is to compile individual functions using `cmpfun()`, but this obviously doesn't scale. If you create a package, you can automatically compile the package on installation by adding
-
-```
-ByteCompile: true
-```
-
-to the `DESCRIPTION` file. Most R packages installed using `install.packages()` are not compiled. We can enable (or force) packages to be compiled by starting R with the environment variable `R_COMPILE_PKGS` set to a positive integer value and specify that we install the package from `source`, i.e.
-
-```{r eval=FALSE}
-## Windows users will need Rtools
-install.packages("ggplot2", type = "source")
-```
-
-Or if we want to avoid altering the `.Renviron` file, we can specify an additional argument
-
-```{r eval=FALSE}
-install.packages("ggplot2", type = "source", INSTALL_opts = "--byte-compile")
-```
+There are a number of ways to compile code. The easiest is to compile individual functions using `cmpfun()`, but this obviously doesn't scale. If you create a package, you can automatically compile the package on installation. This is achieved by the `ByteCompile` logical field on the `DESCRIPTION` file, whose default value is `true`. Similarly, all packages are by default byte-compiled on installation since R 3.5.0.
 
 A final option is to use just-in-time (JIT) compilation. The `enableJIT()` function disables JIT compilation if the argument is `0`. Arguments `1`, `2`, or `3` implement different levels of optimisation. JIT can also be enabled by setting the environment variable `R_ENABLE_JIT`, to one of these values.
 


### PR DESCRIPTION
Since R 3.5.0 (cf. https://cran.r-project.org/doc/manuals/r-release/NEWS.3.html)

Also, we do not need to specify the `ByteCompile` logical filed on the `DESCRIPTION` file. It is turned on by default (cf. https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Creating-R-packages)