### PR TITLE
Fix for parsing errors of Section 5.3.1 in 05-input-output.Rmd

### DIFF
--- a/05-input-output.Rmd
+++ b/05-input-output.Rmd
@@ -150,11 +150,11 @@ When we run the equivalent operation using **readr**,
 voyages_readr = readr::read_tsv(fname)
 ```
 
-a warning is raised regarding row 2841 in the `built` variable. This is because `read_*()` decides what class each variable is based on the first $1000$ rows, rather than all rows, as base `read.*()` functions do. Printing the offending element
+a warning is raised regarding row 1023 in the `hired` variable. This is because `read_*()` decides what class each variable is based on the first $1000$ rows, rather than all rows, as base `read.*()` functions do. Printing the offending element
 
 ```{r}
-voyages_base$built[2841] # a factor.
-voyages_readr$built[2841] # an NA: text cannot be converted to numeric
+voyages_base$hired[1023] # a character
+voyages_readr$hired[1023] # an NA: text cannot be converted to logical(i.e read_*() interprets this column as logical)
 ```
 
 Reading the file using **data.table** 


### PR DESCRIPTION
This is a potential fix for: csgillespie/efficientR#282

code in Section 5.3.1:
```
voyages_readr = readr::read_tsv(fname)

```
generates below output. 

![image](https://user-images.githubusercontent.com/21002508/98355335-03e4ea00-2048-11eb-9e70-1c880642b381.png)

There seems to be parsing errors at rows 1023,1025 and so on(this aligns with what @engineerchange has mentioned in csgillespie/efficientR#282 ). Not exactly sure why the [current version](https://csgillespie.github.io/efficientR/input-output.html#differences-between-fread-and-read_csv) in the book has parsing error at 2841 row. This row seems fine when I run now.

So, I have updated the markdown comments and code appropriately below comparing read.*() VS read_*() for offending value at row 1023. The read.*() decides **hired** column as *char*, whereas read_*() decides **hired** column as *logical* since the first 1000 row values of **hired** column are NAs.

**Note**: read.*() interpretation of **hired** column as *char* aligns with the intended classes of the VOC data frame that I found at the link [here](https://relational.fit.cvut.cz/assets/img/datasets-generated/voc.svg)

![image](https://user-images.githubusercontent.com/21002508/98356195-3ba06180-2049-11eb-80ba-8d4a0ac421d7.png)

@Robinlovelace  Please review and let me know your thoughts. 