### PR TITLE
Update 06-data-carpentry.Rmd

### DIFF
--- a/06-data-carpentry.Rmd
+++ b/06-data-carpentry.Rmd
@@ -544,8 +544,8 @@ library(rlang)
 group_by(cars, speed = cut(speed, c(0, 10, 100))) %>%
   summarise(mean_dist = mean(dist))
 # 2: Evaluation from character string
-group_by(cars, speed = !!parse_quosure("cut(speed, c(0, 10, 100))")) %>%
-  summarise(mean_dist = !!parse_quosure("mean(dist)"))
+group_by(cars, speed = !!parse_quo("cut(speed, c(0, 10, 100))", env = caller_env())) %>%
+  summarise(mean_dist = !!parse_quo("mean(dist)", env = caller_env()))
 # 3: Using !! to evaluate 'quosures' when appropriate
 q1 = quo(cut(speed, c(0, 10, 100)))
 q2 = quo(mean(dist))


### PR DESCRIPTION
Building the book using the most recent version of `{rlang}` will exit with an error because `parse_quosure()` has been deprecated. This PR fixes this.