### PR TITLE
Fix a typo

### DIFF
--- a/03-programming.Rmd
+++ b/03-programming.Rmd
@@ -481,7 +481,7 @@ two_cols[, 1:2]          # a data.frame
 two_cols[, 1]            # an integer vector
 ```
 
-This can cause unexpected problems. The functions `lapply()` and `vapply()` are type consistent. Likewise for `dplyr::select()` and `dplyr:filter()`. The **purrr** package has some type consistent alternatives to base R functions. For example, `map_dbl()` (and other `map_*` functions) to replace `Map()` and `flatten_df()` to replace `unlist()`.
+This can cause unexpected problems. The functions `lapply()` and `vapply()` are type consistent. Likewise for `dplyr::select()` and `dplyr::filter()`. The **purrr** package has some type consistent alternatives to base R functions. For example, `map_dbl()` (and other `map_*` functions) to replace `Map()` and `flatten_df()` to replace `unlist()`.
 
 #### Other resources {-}
 


### PR DESCRIPTION
It fixes a typo by changing `dplyr:filter()` to `dplyr::filter()`.